### PR TITLE
Single file quagga configuration

### DIFF
--- a/manifests/bgpd.pp
+++ b/manifests/bgpd.pp
@@ -15,7 +15,7 @@ class quagga::bgpd (
   $bgp_generic_options = $quagga::params::bgp_generic_options,
 ) {
 
-  unless $quagga::single_config_file {
+  if $quagga::single_config_file == false {
     file { '/etc/quagga/bgpd.conf':
       mode    => '0644',
       owner   => 'quagga',

--- a/manifests/bgpd.pp
+++ b/manifests/bgpd.pp
@@ -15,11 +15,13 @@ class quagga::bgpd (
   $bgp_generic_options = $quagga::params::bgp_generic_options,
 ) {
 
-  file { '/etc/quagga/bgpd.conf':
-    mode    => '0644',
-    owner   => 'quagga',
-    group   => 'quagga',
-    content => template('quagga/bgpd.conf.erb'),
-    notify  => Service['quagga'],
+  unless $quagga::single_config_file {
+    file { '/etc/quagga/bgpd.conf':
+      mode    => '0644',
+      owner   => 'quagga',
+      group   => 'quagga',
+      content => template('quagga/bgpd.conf.erb'),
+      notify  => Service['quagga'],
+    }
   }
 }

--- a/manifests/bgpd.pp
+++ b/manifests/bgpd.pp
@@ -15,7 +15,7 @@ class quagga::bgpd (
   $bgp_generic_options = $quagga::params::bgp_generic_options,
 ) {
 
-  if $quagga::single_config_file == false {
+  unless $quagga::single_config_file == true {
     file { '/etc/quagga/bgpd.conf':
       mode    => '0644',
       owner   => 'quagga',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -89,7 +89,7 @@ class quagga (
     }
   }
 
-  if $single_config_file {
+  if $single_config_file == true {
     include quagga::quagga
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,16 +11,17 @@
 # === License
 # Apache v2
 class quagga (
-  $manage_package = $quagga::params::manage_package,
-  $manage_service = $quagga::params::manage_service,
-  $zebra          = $quagga::params::zebra,
-  $bgpd           = $quagga::params::bgpd,
-  $ospfd          = $quagga::params::ospfd,
-  $ospf6d         = $quagga::params::ospf6d,
-  $ripd           = $quagga::params::ripd,
-  $ripngd         = $quagga::params::ripngd,
-  $isisd          = $quagga::params::isisd,
-  $babeld         = $quagga::params::babeld,
+  $manage_package     = $quagga::params::manage_package,
+  $manage_service     = $quagga::params::manage_service,
+  $single_config_file = $quagga::params::single_config_file,
+  $zebra              = $quagga::params::zebra,
+  $bgpd               = $quagga::params::bgpd,
+  $ospfd              = $quagga::params::ospfd,
+  $ospf6d             = $quagga::params::ospf6d,
+  $ripd               = $quagga::params::ripd,
+  $ripngd             = $quagga::params::ripngd,
+  $isisd              = $quagga::params::isisd,
+  $babeld             = $quagga::params::babeld,
 ) inherits quagga::params {
   if $manage_package {
     package { 'quagga':
@@ -54,35 +55,41 @@ class quagga (
     }
   }
 
-  if $zebra == true {
-    include quagga::zebra
+  unless $single_config_file {
+    if $zebra == true {
+      include quagga::zebra
+    }
+
+    if $bgpd == true {
+      include quagga::bgpd
+    }
+
+    if $ospfd == true {
+      include quagga::ospfd
+    }
+
+    if $ospf6d == true {
+      include quagga::ospf6d
+    }
+
+    if $ripd == true {
+      include quagga::ripd
+    }
+
+    if $ripngd == true {
+      include quagga::ripngd
+    }
+
+    if $isisd == true {
+      include quagga::isisd
+    }
+
+    if $babeld == true {
+      include quagga::babeld
+    }
   }
 
-  if $bgpd == true {
-    include quagga::bgpd
-  }
-
-  if $ospfd == true {
-    include quagga::ospfd
-  }
-
-  if $ospf6d == true {
-    include quagga::ospf6d
-  }
-
-  if $ripd == true {
-    include quagga::ripd
-  }
-
-  if $ripngd == true {
-    include quagga::ripngd
-  }
-
-  if $isisd == true {
-    include quagga::isisd
-  }
-
-  if $babeld == true {
-    include quagga::babeld
+  if $single_config_file {
+    include quagga::quagga
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,7 +55,7 @@ class quagga (
     }
   }
 
-  unless $single_config_file {
+  if $single_config_file == false {
     if $zebra == true {
       include quagga::zebra
     }

--- a/manifests/isisd.pp
+++ b/manifests/isisd.pp
@@ -2,7 +2,7 @@
 
 class quagga::isisd {
 
-  unless $quagga::single_config_file {
+  unless $quagga::single_config_file == true {
     file { '/etc/quagga/isisd.conf':
       mode    => '0644'.
       owner   => 'quagga',

--- a/manifests/isisd.pp
+++ b/manifests/isisd.pp
@@ -2,6 +2,7 @@
 
 class quagga::isisd {
 
+  unless $quagga::single_config_file {
     file { '/etc/quagga/isisd.conf':
       mode    => '0644'.
       owner   => 'quagga',
@@ -9,4 +10,5 @@ class quagga::isisd {
       content => template('quagga/isisd.conf.erb'),
       notify  => Service['quagga'],
     }
+  }
 }

--- a/manifests/ospf6d.pp
+++ b/manifests/ospf6d.pp
@@ -2,7 +2,7 @@
 
 class quagga::ospf6d {
 
-  unless $quagga::single_config_file {
+  unless $quagga::single_config_file == true {
     file { '/etc/quagga/ospf6d.conf':
       mode    => '0644'.
       owner   => 'quagga',

--- a/manifests/ospf6d.pp
+++ b/manifests/ospf6d.pp
@@ -2,6 +2,7 @@
 
 class quagga::ospf6d {
 
+  unless $quagga::single_config_file {
     file { '/etc/quagga/ospf6d.conf':
       mode    => '0644'.
       owner   => 'quagga',
@@ -9,4 +10,5 @@ class quagga::ospf6d {
       content => template('quagga/ospf6d.conf.erb'),
       notify  => Service['quagga'],
     }
+  }
 }

--- a/manifests/ospfd.pp
+++ b/manifests/ospfd.pp
@@ -2,7 +2,7 @@
 
 class quagga::ospfd {
 
-  unless $quagga::single_config_file {
+  unless $quagga::single_config_file == true {
     file { '/etc/quagga/ospfd.conf':
       mode    => '0644'.
       owner   => 'quagga',

--- a/manifests/ospfd.pp
+++ b/manifests/ospfd.pp
@@ -2,6 +2,7 @@
 
 class quagga::ospfd {
 
+  unless $quagga::single_config_file {
     file { '/etc/quagga/ospfd.conf':
       mode    => '0644'.
       owner   => 'quagga',
@@ -9,4 +10,5 @@ class quagga::ospfd {
       content => template('quagga/ospfd.conf.erb'),
       notify  => Service['quagga'],
     }
+  }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,6 +4,8 @@ class quagga::params {
 
   $manage_package = true
   $manage_service = true
+  # Cumulus Linux defaults to use a single config file, Quagga.conf
+  $single_config_file = false
   # running zebra is highly recommended
   $zebra  = true
   $bgpd   = false

--- a/manifests/quagga.pp
+++ b/manifests/quagga.pp
@@ -1,0 +1,35 @@
+#Class quagga::quagga
+#
+# For single config file deployments
+#
+# Supports zebra/bgpd for now
+
+class quagga::quagga (
+  $bgp_hostname          = $quagga::params::bgp_hostname,
+  $bgp_password          = $quagga::params::bgp_password,
+  $bgp_logfile           = $quagga::params::bgp_logfile,
+  $bgp_as                = $quagga::params::bgp_as,
+  $bgp_options           = $quagga::params::bgp_options,
+  $bgp_networks          = $quagga::params::bgp_networks,
+  $bgp_neighbors         = $quagga::params::bgp_neighbors,
+  $bgp_neighbor_groups   = $quagga::params::bgp_neighbor_groups,
+  $bgp_accesslist        = $quagga::params::bgp_accesslist,
+  $bgp_ip_prefix_list    = $quagga::params::bgp_ip_prefix_list,
+  $bgp_route_maps        = $quagga::params::bgp_route_maps,
+  $bgp_generic_options   = $quagga::params::bgp_generic_options,
+  $zebra_password        = $quagga::params::zebra_password,
+  $zebra_enable_password = $quagga::params::zebra_enable_password,
+  $zebra_log_file        = $quagga::params::zebra_log_file,
+  $zebra_ip_routes       = $quagga::params::zebra_ip_routes,
+  $zebra_interfaces      = $quagga::params::zebra_interfaces,
+  $zebra_generic_options = $quagga::params::zebra_generic_options,
+) {
+
+  file { '/etc/quagga/Quagga.conf':
+    mode    => '0644',
+    owner   => 'quagga',
+    group   => 'quagga',
+    content => template('quagga/Quagga.conf.erb'),
+    notify  => Service['quagga'],
+  }
+}

--- a/manifests/ripd.pp
+++ b/manifests/ripd.pp
@@ -2,7 +2,7 @@
 
 class quagga::ripd {
 
-  unless $quagga::single_config_file {
+  unless $quagga::single_config_file == true {
     file { '/etc/quagga/ripd.conf':
       mode    => '0644'.
       owner   => 'quagga',

--- a/manifests/ripd.pp
+++ b/manifests/ripd.pp
@@ -2,6 +2,7 @@
 
 class quagga::ripd {
 
+  unless $quagga::single_config_file {
     file { '/etc/quagga/ripd.conf':
       mode    => '0644'.
       owner   => 'quagga',
@@ -9,4 +10,5 @@ class quagga::ripd {
       content => template('quagga/ripd.conf.erb'),
       notify  => Service['quagga'],
     }
+  }
 }

--- a/manifests/ripngd.pp
+++ b/manifests/ripngd.pp
@@ -2,7 +2,7 @@
 
 class quagga::ripngd {
 
-  unless $quagga::single_config_file {
+  unless $quagga::single_config_file == true {
     file { '/etc/quagga/ripngd.conf':
       mode    => '0644'.
       owner   => 'quagga',

--- a/manifests/ripngd.pp
+++ b/manifests/ripngd.pp
@@ -2,6 +2,7 @@
 
 class quagga::ripngd {
 
+  unless $quagga::single_config_file {
     file { '/etc/quagga/ripngd.conf':
       mode    => '0644'.
       owner   => 'quagga',
@@ -9,4 +10,5 @@ class quagga::ripngd {
       content => template('quagga/ripngd.conf.erb'),
       notify  => Service['quagga'],
     }
+  }
 }

--- a/manifests/zebra.pp
+++ b/manifests/zebra.pp
@@ -8,7 +8,7 @@ class quagga::zebra (
   $zebra_generic_options = $quagga::params::zebra_generic_options,
 ) {
 
-  unless $single_config_file {
+  unless $single_config_file == true {
     file { '/etc/quagga/zebra.conf':
       mode    => '0644',
       owner   => 'quagga',

--- a/manifests/zebra.pp
+++ b/manifests/zebra.pp
@@ -7,6 +7,8 @@ class quagga::zebra (
   $zebra_interfaces      = $quagga::params::zebra_interfaces,
   $zebra_generic_options = $quagga::params::zebra_generic_options,
 ) {
+
+  unless $single_config_file {
     file { '/etc/quagga/zebra.conf':
       mode    => '0644',
       owner   => 'quagga',
@@ -14,4 +16,5 @@ class quagga::zebra (
       content => template('quagga/zebra.conf.erb'),
       notify  => Service['quagga'],
     }
+  }
 }

--- a/templates/Quagga.conf.erb
+++ b/templates/Quagga.conf.erb
@@ -1,0 +1,43 @@
+log timestamp precision 6
+username cumulus nopassword
+log file <%= @zebra_log_file %>
+!
+<% if @zebra_interfaces -%><% zebra_interfaces.each do |name| %> interface <%= name[0] %> <% (0..name[1].length).each do |i| %>
+<% if name[1][i] %>  <%= name[1][i]%><% end %><% end %>!
+<% end %><% end -%>
+router bgp <%= scope.lookupvar('bgp_as') %>
+<% if @bgp_options -%><% (1..bgp_options.length).each do |i| %> bgp <%= bgp_options[i-1] %>
+<% end%>!
+<% end -%>
+<% if @bgp_networks -%><% (1..bgp_networks.length).each do |i| %> network <%= bgp_networks[i-1] %>
+<% end%>!
+<% end -%>
+<% if @bgp_neighbor_groups -%><% bgp_neighbor_groups.each do |name| %><% (0..name[1]['options'].length).each do |i| %><%
+ if name[1]['options'][i] %> neighbor <%= name[0] %> <%= name[1]['options'][i]%>
+<% end %><% end %><% if name[1]['members'] %><%
+(0..name[1]['members'].length).each do |i| %><% if name[1]['members'][i] %> neighbor <%= name[1]['members'][i]%> peer-group <%= name[0] %>
+<% end %><% end %><% end %><% end %>!
+<% end -%>
+<% if @bgp_neighbors -%><% (1..bgp_neighbors.length).each do |i| %> neighbor <%= bgp_neighbors[i-1] %>
+<% end%>!
+<% end -%>
+<% if @zebra_ip_routes -%><% (1..zebra_ip_routes.length).each do |i| %> ip route <%= zebra_ip_routes[i-1] %>
+<% end%>!
+<% end -%>
+<% if @zebra_generic_options -%><% zebra_generic_options.each do |name| %> <%= name[0] %> <%= name[1] %>
+<% end %><% end -%>
+<% if @bgp_accesslist -%><% bgp_accesslist.each do |name| %><% (0..name[1].length).each do |i| %><%
+ if name[1][i] %> access-list <%= name[0] %> <%= name[1][i]%>
+<% end %><% end %><% end %>!
+<% end -%>
+<% if @bgp_ip_prefix_list -%><% (1..bgp_ip_prefix_list.length).each do |i| %> ip prefix-list <%= bgp_ip_prefix_list[i-1] %>
+<% end%>!
+<% end -%>
+<% if @bgp_route_maps -%><% bgp_route_maps.each do |name| %> route-map <%= name[0] %> <% (0..name[1].length).each do |i| %>
+<% if name[1][i] %>  <%= name[1][i]%><% end %><% end %>!
+<% end %><% end -%>
+<% if @bgp_generic_options -%><% bgp_generic_options.each do |name| %> <%= name[0] %> <%= name[1] %>
+<% end %><% end -%>
+!
+line vty
+!

--- a/templates/Quagga.conf.erb
+++ b/templates/Quagga.conf.erb
@@ -24,8 +24,6 @@ router bgp <%= scope.lookupvar('bgp_as') %>
 <% if @zebra_ip_routes -%><% (1..zebra_ip_routes.length).each do |i| %> ip route <%= zebra_ip_routes[i-1] %>
 <% end%>!
 <% end -%>
-<% if @zebra_generic_options -%><% zebra_generic_options.each do |name| %> <%= name[0] %> <%= name[1] %>
-<% end %><% end -%>
 <% if @bgp_accesslist -%><% bgp_accesslist.each do |name| %><% (0..name[1].length).each do |i| %><%
  if name[1][i] %> access-list <%= name[0] %> <%= name[1][i]%>
 <% end %><% end %><% end %>!
@@ -37,6 +35,8 @@ router bgp <%= scope.lookupvar('bgp_as') %>
 <% if name[1][i] %>  <%= name[1][i]%><% end %><% end %>!
 <% end %><% end -%>
 <% if @bgp_generic_options -%><% bgp_generic_options.each do |name| %> <%= name[0] %> <%= name[1] %>
+<% end %><% end -%>
+<% if @zebra_generic_options -%><% zebra_generic_options.each do |name| %> <%= name[0] %> <%= name[1] %>
 <% end %><% end -%>
 !
 line vty


### PR DESCRIPTION
By default, Cumulus Linux uses a single configuration file, Quagga.conf, instead of separate files pr daemon. These changes enables the option of using a single configuration file. Defaults to false.

For now, only zebra/bgpd is supported in single file configuration.
