### PR TITLE
Some IPv6 support for bgp and zebra

### DIFF
--- a/manifests/bgpd.pp
+++ b/manifests/bgpd.pp
@@ -7,6 +7,7 @@ class quagga::bgpd (
   $bgp_as              = $quagga::params::bgp_as,
   $bgp_options         = $quagga::params::bgp_options,
   $bgp_networks        = $quagga::params::bgp_networks,
+  $bgp_networks6       = $quagga::params::bgp_networks6,
   $bgp_neighbors       = $quagga::params::bgp_neighbors,
   $bgp_neighbor_groups = $quagga::params::bgp_neighbor_groups,
   $bgp_accesslist      = $quagga::params::bgp_accesslist,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -41,6 +41,7 @@ class quagga::params {
   #$bgp_networks is an array of bgp networks, ie
   # quagga::bgpd::bgp_networks => [ '0.0.0.0/0', '192.168.0.0/24', ],
   $bgp_networks = undef
+  $bgp_networks6 = undef
   #$bgp_options is an array of bgp options, ie
   # quagga::bgpd::bgp_options => [ 'log-neighbor-changes', 'router-id 192.168.0.1', ],
   $bgp_options = undef

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,9 +23,10 @@ class quagga::params {
   $zebra_password = 'cn321'
   $zebra_enable_password = 'cn321'
   $zebra_log_file = '/var/log/quagga/zebra.log'
-  #$zebra_ip-route is an array of routes, ie
+  #$zebra_ip-routes is an array of routes, ie
   # quagga::zebra:bgp_ip-route => [ '0.0.0.0/0 192.168.0.1', '10.0.0.0/24 10.0.0.1', ],
-  $zebra_ip_route = undef
+  $zebra_ip_routes = undef
+  $zebra_ip6_routes = undef
   #$zebra_interfaces is a hash of arrays with interface parameters
   $zebra_interfaces = undef
   #$zebra_generic_options is an array of generic options for bgpd, ie

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -38,7 +38,7 @@ class quagga::params {
   $bgp_password = 'cn321'
   $bgp_as = '65001'
   $bgp_logfile = '/var/log/quagga/bgpd.log'
-  #$bgp_networks is an array of bgp networks, ie
+  #$bgp_networks and bgp_networks6 are arrays of bgp networks, ie
   # quagga::bgpd::bgp_networks => [ '0.0.0.0/0', '192.168.0.0/24', ],
   $bgp_networks = undef
   $bgp_networks6 = undef
@@ -47,6 +47,7 @@ class quagga::params {
   $bgp_options = undef
   #$bgp_neighbor_group is a hash of arrays with group names and options, ie
   # quagga::bgpd::bgp_neighbor_groups => { 'name-of-group': options => [ 'peer-group', 'remote-as 65535', ], members => [ '192.168.0.10', '192.168.0.11', ], }
+  # You can add members and/or members6 (also specify networks6)
   $bgp_neighbor_groups = undef
   #$bgp_neighbors is an array of of neighbor comands
   $bgp_neighbors = undef

--- a/manifests/quagga.pp
+++ b/manifests/quagga.pp
@@ -11,6 +11,7 @@ class quagga::quagga (
   $bgp_as                = $quagga::params::bgp_as,
   $bgp_options           = $quagga::params::bgp_options,
   $bgp_networks          = $quagga::params::bgp_networks,
+  $bgp_networks6         = $quagga::params::bgp_networks6,
   $bgp_neighbors         = $quagga::params::bgp_neighbors,
   $bgp_neighbor_groups   = $quagga::params::bgp_neighbor_groups,
   $bgp_accesslist        = $quagga::params::bgp_accesslist,

--- a/manifests/quagga.pp
+++ b/manifests/quagga.pp
@@ -20,6 +20,7 @@ class quagga::quagga (
   $zebra_password        = $quagga::params::zebra_password,
   $zebra_enable_password = $quagga::params::zebra_enable_password,
   $zebra_log_file        = $quagga::params::zebra_log_file,
+  $zebra_ip6_routes      = $quagga::params::zebra_ip6_routes,
   $zebra_ip_routes       = $quagga::params::zebra_ip_routes,
   $zebra_interfaces      = $quagga::params::zebra_interfaces,
   $zebra_generic_options = $quagga::params::zebra_generic_options,

--- a/manifests/zebra.pp
+++ b/manifests/zebra.pp
@@ -3,6 +3,7 @@ class quagga::zebra (
   $zebra_password        = $quagga::params::zebra_password,
   $zebra_enable_password = $quagga::params::zebra_enable_password,
   $zebra_log_file        = $quagga::params::zebra_log_file,
+  $zebra_ip6_routes      = $quagga::params::zebra_ip6_routes,
   $zebra_ip_routes       = $quagga::params::zebra_ip_routes,
   $zebra_interfaces      = $quagga::params::zebra_interfaces,
   $zebra_generic_options = $quagga::params::zebra_generic_options,

--- a/templates/Quagga.conf.erb
+++ b/templates/Quagga.conf.erb
@@ -21,6 +21,8 @@ router bgp <%= scope.lookupvar('bgp_as') %>
 <% if @bgp_neighbors -%><% (1..bgp_neighbors.length).each do |i| %> neighbor <%= bgp_neighbors[i-1] %>
 <% end%>!
 <% end -%>
+<% if @zebra_ip6_routes -%><% (1..zebra_ip6_routes.length).each do |i| %> ipv6 route <%= zebra_ip6_routes[i-1] %>
+<% end%>
 <% if @zebra_ip_routes -%><% (1..zebra_ip_routes.length).each do |i| %> ip route <%= zebra_ip_routes[i-1] %>
 <% end%>!
 <% end -%>

--- a/templates/Quagga.conf.erb
+++ b/templates/Quagga.conf.erb
@@ -10,10 +10,11 @@ router bgp <%= scope.lookupvar('bgp_as') %>
 <% end%>!
 <% end -%>
 <% if @bgp_networks6 -%>
-address-family ipv6
+ address-family ipv6
 <% (1..bgp_networks6.length).each do |i| %> network <%= bgp_networks6[i-1] %>
-exit-address-family
-<% end%>!
+<% end%> exit-address-family
+!
+<% end -%>
 <% if @bgp_networks -%><% (1..bgp_networks.length).each do |i| %> network <%= bgp_networks[i-1] %>
 <% end%>!
 <% end -%>
@@ -27,7 +28,8 @@ exit-address-family
 <% end%>!
 <% end -%>
 <% if @zebra_ip6_routes -%><% (1..zebra_ip6_routes.length).each do |i| %> ipv6 route <%= zebra_ip6_routes[i-1] %>
-<% end%>
+<% end%>!
+<% end -%>
 <% if @zebra_ip_routes -%><% (1..zebra_ip_routes.length).each do |i| %> ip route <%= zebra_ip_routes[i-1] %>
 <% end%>!
 <% end -%>

--- a/templates/Quagga.conf.erb
+++ b/templates/Quagga.conf.erb
@@ -9,7 +9,10 @@ router bgp <%= scope.lookupvar('bgp_as') %>
 <% if @bgp_options -%><% (1..bgp_options.length).each do |i| %> bgp <%= bgp_options[i-1] %>
 <% end%>!
 <% end -%>
-<% if @bgp_networks6 -%><% (1..bgp_networks6.length).each do |i| %> network <%= bgp_networks6[i-1] %>
+<% if @bgp_networks6 -%>
+address-family ipv6
+<% (1..bgp_networks6.length).each do |i| %> network <%= bgp_networks6[i-1] %>
+exit-address-family
 <% end%>!
 <% if @bgp_networks -%><% (1..bgp_networks.length).each do |i| %> network <%= bgp_networks[i-1] %>
 <% end%>!

--- a/templates/Quagga.conf.erb
+++ b/templates/Quagga.conf.erb
@@ -9,6 +9,8 @@ router bgp <%= scope.lookupvar('bgp_as') %>
 <% if @bgp_options -%><% (1..bgp_options.length).each do |i| %> bgp <%= bgp_options[i-1] %>
 <% end%>!
 <% end -%>
+<% if @bgp_networks6 -%><% (1..bgp_networks6.length).each do |i| %> network <%= bgp_networks6[i-1] %>
+<% end%>!
 <% if @bgp_networks -%><% (1..bgp_networks.length).each do |i| %> network <%= bgp_networks[i-1] %>
 <% end%>!
 <% end -%>

--- a/templates/Quagga.conf.erb
+++ b/templates/Quagga.conf.erb
@@ -9,12 +9,6 @@ router bgp <%= scope.lookupvar('bgp_as') %>
 <% if @bgp_options -%><% (1..bgp_options.length).each do |i| %> bgp <%= bgp_options[i-1] %>
 <% end%>!
 <% end -%>
-<% if @bgp_networks6 -%>
- address-family ipv6
-<% (1..bgp_networks6.length).each do |i| %> network <%= bgp_networks6[i-1] %>
-<% end%> exit-address-family
-!
-<% end -%>
 <% if @bgp_networks -%><% (1..bgp_networks.length).each do |i| %> network <%= bgp_networks[i-1] %>
 <% end%>!
 <% end -%>
@@ -26,6 +20,12 @@ router bgp <%= scope.lookupvar('bgp_as') %>
 <% end -%>
 <% if @bgp_neighbors -%><% (1..bgp_neighbors.length).each do |i| %> neighbor <%= bgp_neighbors[i-1] %>
 <% end%>!
+<% end -%>
+<% if @bgp_networks6 -%>
+ address-family ipv6
+<% (1..bgp_networks6.length).each do |i| %> network <%= bgp_networks6[i-1] %>
+<% end%> exit-address-family
+!
 <% end -%>
 <% if @zebra_ip6_routes -%><% (1..zebra_ip6_routes.length).each do |i| %> ipv6 route <%= zebra_ip6_routes[i-1] %>
 <% end%>!

--- a/templates/Quagga.conf.erb
+++ b/templates/Quagga.conf.erb
@@ -22,7 +22,11 @@ router bgp <%= scope.lookupvar('bgp_as') %>
 <% end%>!
 <% end -%>
 <% if @bgp_networks6 -%>
- address-family ipv6
+ address-family ipv6 <% if @bgp_neighbor_groups -%><% bgp_neighbor_groups.each do |name| %><% if name[1]['members6'] %>
+ neighbor <%= name[0] %> activate
+<%
+(0..name[1]['members6'].length).each do |i| %><% if name[1]['members6'][i] %> neighbor <%= name[1]['members6'][i]%> peer-group <%= name[0] %>
+<% end %><% end %><% end %><% end %><% end -%>
 <% (1..bgp_networks6.length).each do |i| %> network <%= bgp_networks6[i-1] %>
 <% end%> exit-address-family
 !

--- a/templates/bgpd.conf.erb
+++ b/templates/bgpd.conf.erb
@@ -7,7 +7,10 @@ router bgp <%= scope.lookupvar('bgp_as') %>
 <% if @bgp_options -%><% (1..bgp_options.length).each do |i| %> bgp <%= bgp_options[i-1] %>
 <% end%>!
 <% end -%>
-<% if @bgp_networks6 -%><% (1..bgp_networks6.length).each do |i| %> network <%= bgp_networks6[i-1] %>
+<% if @bgp_networks6 -%>
+address-family ipv6
+<% (1..bgp_networks6.length).each do |i| %> network <%= bgp_networks6[i-1] %>
+exit-address-family
 <% end%>!
 <% if @bgp_networks -%><% (1..bgp_networks.length).each do |i| %> network <%= bgp_networks[i-1] %>
 <% end%>!

--- a/templates/bgpd.conf.erb
+++ b/templates/bgpd.conf.erb
@@ -8,10 +8,11 @@ router bgp <%= scope.lookupvar('bgp_as') %>
 <% end%>!
 <% end -%>
 <% if @bgp_networks6 -%>
-address-family ipv6
+ address-family ipv6
 <% (1..bgp_networks6.length).each do |i| %> network <%= bgp_networks6[i-1] %>
-exit-address-family
-<% end%>!
+<% end%> exit-address-family
+!
+<% end -%>
 <% if @bgp_networks -%><% (1..bgp_networks.length).each do |i| %> network <%= bgp_networks[i-1] %>
 <% end%>!
 <% end -%>

--- a/templates/bgpd.conf.erb
+++ b/templates/bgpd.conf.erb
@@ -7,6 +7,8 @@ router bgp <%= scope.lookupvar('bgp_as') %>
 <% if @bgp_options -%><% (1..bgp_options.length).each do |i| %> bgp <%= bgp_options[i-1] %>
 <% end%>!
 <% end -%>
+<% if @bgp_networks6 -%><% (1..bgp_networks6.length).each do |i| %> network <%= bgp_networks6[i-1] %>
+<% end%>!
 <% if @bgp_networks -%><% (1..bgp_networks.length).each do |i| %> network <%= bgp_networks[i-1] %>
 <% end%>!
 <% end -%>

--- a/templates/bgpd.conf.erb
+++ b/templates/bgpd.conf.erb
@@ -7,12 +7,6 @@ router bgp <%= scope.lookupvar('bgp_as') %>
 <% if @bgp_options -%><% (1..bgp_options.length).each do |i| %> bgp <%= bgp_options[i-1] %>
 <% end%>!
 <% end -%>
-<% if @bgp_networks6 -%>
- address-family ipv6
-<% (1..bgp_networks6.length).each do |i| %> network <%= bgp_networks6[i-1] %>
-<% end%> exit-address-family
-!
-<% end -%>
 <% if @bgp_networks -%><% (1..bgp_networks.length).each do |i| %> network <%= bgp_networks[i-1] %>
 <% end%>!
 <% end -%>
@@ -24,6 +18,12 @@ router bgp <%= scope.lookupvar('bgp_as') %>
 <% end -%>
 <% if @bgp_neighbors -%><% (1..bgp_neighbors.length).each do |i| %> neighbor <%= bgp_neighbors[i-1] %>
 <% end%>!
+<% end -%>
+<% if @bgp_networks6 -%>
+ address-family ipv6
+<% (1..bgp_networks6.length).each do |i| %> network <%= bgp_networks6[i-1] %>
+<% end%> exit-address-family
+!
 <% end -%>
 <% if @bgp_accesslist -%><% bgp_accesslist.each do |name| %><% (0..name[1].length).each do |i| %><%
  if name[1][i] %> access-list <%= name[0] %> <%= name[1][i]%>

--- a/templates/bgpd.conf.erb
+++ b/templates/bgpd.conf.erb
@@ -20,7 +20,11 @@ router bgp <%= scope.lookupvar('bgp_as') %>
 <% end%>!
 <% end -%>
 <% if @bgp_networks6 -%>
- address-family ipv6
+ address-family ipv6 <% if @bgp_neighbor_groups -%><% bgp_neighbor_groups.each do |name| %><% if name[1]['members6'] %>
+ neighbor <%= name[0] %> activate
+<%
+(0..name[1]['members6'].length).each do |i| %><% if name[1]['members6'][i] %> neighbor <%= name[1]['members6'][i]%> peer-group <%= name[0] %>
+<% end %><% end %><% end %><% end %><% end -%>
 <% (1..bgp_networks6.length).each do |i| %> network <%= bgp_networks6[i-1] %>
 <% end%> exit-address-family
 !

--- a/templates/zebra.conf.erb
+++ b/templates/zebra.conf.erb
@@ -7,6 +7,8 @@ log file <%= @zebra_log_file %>
 <% if name[1][i] %>  <%= name[1][i]%><% end %><% end %>!
 <% end %><% end -%>
 
+<% if @zebra_ip6_routes -%><% (1..zebra_ip6_routes.length).each do |i| %> ipv6 route <%= zebra_ip6_routes[i-1] %>
+<% end%>
 <% if @zebra_ip_routes -%><% (1..zebra_ip_routes.length).each do |i| %> ip route <%= zebra_ip_routes[i-1] %>
 <% end%>!
 <% end -%>

--- a/templates/zebra.conf.erb
+++ b/templates/zebra.conf.erb
@@ -8,7 +8,8 @@ log file <%= @zebra_log_file %>
 <% end %><% end -%>
 
 <% if @zebra_ip6_routes -%><% (1..zebra_ip6_routes.length).each do |i| %> ipv6 route <%= zebra_ip6_routes[i-1] %>
-<% end%>
+<% end%>!
+<% end -%>
 <% if @zebra_ip_routes -%><% (1..zebra_ip_routes.length).each do |i| %> ip route <%= zebra_ip_routes[i-1] %>
 <% end%>!
 <% end -%>


### PR DESCRIPTION
These changes makes it possible to activate peer-groups for IPv6 and define IPv6 network for zebra and bgp.